### PR TITLE
Add dependent layouts and enums for TOML processing

### DIFF
--- a/tests/Process.idr
+++ b/tests/Process.idr
@@ -90,7 +90,6 @@ basicDependent = test "process table dependent layout" $ assert $ check result
         check (Right (True :: lang :: [])) = lang == "idris"
         check (Right (False :: tbl)) = False
 
-
 basicEnum : Test
 basicEnum = test "process enum" $ assert $ check result
     where
@@ -107,6 +106,7 @@ basicEnum = test "process enum" $ assert $ check result
         check (Left x) = False
         check (Right ("idris" ** _)) = True
         check (Right (_ ** _)) = False
+
 
 export
 tests : List Test

--- a/tests/Process.idr
+++ b/tests/Process.idr
@@ -9,12 +9,13 @@ import Tester
 import Data.List.Quantifiers
 import Language.TOML
 import Language.TOML.Processing
+import Data.List.Elem
 
 basicUnordered : Test
 basicUnordered = test "process unordered table" $ assert $ check result
     where
         Spec : TableTy
-        Spec = [MkFieldTy "name" False TString, MkFieldTy "age" False TInteger]
+        Spec = MkFieldTy "name" False TString `And` MkFieldTy "age" False TInteger `And` Emp
 
         table : Table
         table = fromList [("age", VInteger 999), ("name", VString "John Doe")]
@@ -30,11 +31,13 @@ basicNested : Test
 basicNested = test "process nested table" $ assert $ check result
     where
         Spec : TableTy
-        Spec = [MkFieldTy "name" False TString,
-                MkFieldTy "age" False TInteger,
+        Spec = MkFieldTy "name" False TString `And`
+                MkFieldTy "age" False TInteger `And`
                 MkFieldTy "skills" False (TTable
-                    [MkFieldTy "running" False TInteger,
-                     MkFieldTy "programming" False TInteger])]
+                    (MkFieldTy "running" False TInteger `And`
+                     MkFieldTy "programming" False TInteger `And`
+                     Emp)) `And`
+                Emp
 
         table : Table
         table = fromList [("age", VInteger 999),
@@ -55,7 +58,7 @@ basicOptional : Test
 basicOptional = test "process table with optional field" $ assert $ check result
     where
         Spec : TableTy
-        Spec = [MkFieldTy "name" True TString, MkFieldTy "age" False TInteger]
+        Spec = MkFieldTy "name" True TString `And` MkFieldTy "age" False TInteger `And` Emp
 
         table : Table
         table = fromList [("age", VInteger 999)]
@@ -67,7 +70,44 @@ basicOptional = test "process table with optional field" $ assert $ check result
         check (Left x) = False
         check (Right [name, age]) = name == Nothing && age == 999
 
+basicDependent : Test
+basicDependent = test "process table dependent layout" $ assert $ check result
+    where
+        Spec : TableTy
+        Spec = Ext (MkFieldTy "programmer" False TBoolean) $ \programmer =>
+            if programmer
+               then MkFieldTy "fave-lang" False TString `And` Emp
+               else Emp
+
+        table : Table
+        table = fromList [("programmer", VBoolean True), ("fave-lang", VString "idris")]
+
+        result : Either TableError (TableOf Spec)
+        result = processTable Spec table
+
+        check : Either TableError (TableOf Spec) -> Bool
+        check (Left x) = False
+        check (Right (True :: lang :: [])) = lang == "idris"
+        check (Right (False :: tbl)) = False
+
+
+basicEnum : Test
+basicEnum = test "process enum" $ assert $ check result
+    where
+        Spec : ValueTy
+        Spec = TEnum ["idris", "haskell", "lisp"]
+
+        table : Value
+        table = VString "idris"
+
+        result : Either ValueError (ValueOf Spec)
+        result = processValue Spec table
+
+        check : Either ValueError (ValueOf Spec) -> Bool
+        check (Left x) = False
+        check (Right ("idris" ** _)) = True
+        check (Right (_ ** _)) = False
 
 export
 tests : List Test
-tests = [basicUnordered, basicNested, basicOptional]
+tests = [basicUnordered, basicNested, basicOptional, basicDependent, basicEnum]


### PR DESCRIPTION
Enums allow the user to specify a set of strings that should be accepted, rahter than just using the string type.

Dependent layouts allow the layout to be determined by the value of fields.

A motiviating example using both these features is taken from `sirdi`. Both of the following tables should be a valid definition of a dependency, despite having a different concrete structure.

```toml
type = "git"
url  = "https://.."
commit = "fe2145f..."
```
```toml
type = "local"
path = "/some/path/to/local/dep"
```
With these fields, we can use enums to specify a type field allowing values `["git", "local"]`, and then dependently determine the rest of the required fields depending on which dependency type was given.
